### PR TITLE
TextInput scrolling bug

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -100,16 +100,18 @@ public class ReactEditText extends EditText {
     */
    @Override
    public boolean dispatchTouchEvent(MotionEvent ev) {
-     switch (ev.getAction()) {
-       case MotionEvent.ACTION_DOWN:
-         // Disallow ScrollView to intercept touch events.
-         this.getParent().requestDisallowInterceptTouchEvent(true);
-         break;
-       case MotionEvent.ACTION_UP:
-         // Allow ScrollView to intercept touch events.
-         this.getParent().requestDisallowInterceptTouchEvent(false);
-         break;
-     }
+       if ((getInputType() & InputType.TYPE_TEXT_FLAG_MULTI_LINE) != 0 ) {
+           switch (ev.getAction()) {
+               case MotionEvent.ACTION_DOWN:
+                   // Disallow ScrollView to intercept touch events.
+                   this.getParent().requestDisallowInterceptTouchEvent(true);
+                   break;
+               case MotionEvent.ACTION_UP:
+                   // Allow ScrollView to intercept touch events.
+                   this.getParent().requestDisallowInterceptTouchEvent(false);
+                   break;
+           }
+       }
      return super.dispatchTouchEvent(ev);
    }
 

--- a/package.json
+++ b/package.json
@@ -170,5 +170,5 @@
     "start": "/usr/bin/env bash -c './packager/packager.sh \"$@\" || true' --",
     "test": "NODE_ENV=test jest"
   },
-  "version": "0.27.31"
+  "version": "0.27.32"
 }


### PR DESCRIPTION
ReactEditText dispatchTouchEvent swallow scroll event, but this
may make not-multiline TextInput not triggering scrollview
scrolling.

This patch makes dispatchTouchEvent only working when TextInput
is multiline.